### PR TITLE
Moved debugging/output into Drush callbacks

### DIFF
--- a/digitalmeasures.drush.inc
+++ b/digitalmeasures.drush.inc
@@ -36,12 +36,22 @@ function drush_digitalmeasures_get_schemadata($arguments) {
   // Convert the arguments string into a nested array
   $arguments_array = _digitalmeasures_arguments_string_to_array($arguments);
   // Make request to Digital Measures
-  digitalmeasures_digitalmeasures_get_schemadata($arguments_array);
+  $response = digitalmeasures_digitalmeasures_get_schemadata($arguments_array);
+
+  drush_print_r($response);
+  if (module_exists('devel_debug_log')) {
+    ddl($response);
+  }
 }
 
 /**
  * Drush get all indexes callback.
  */
 function drush_digitalmeasures_get_indexes() {
-  digitalmeasures_digitalmeasures_get_all_indexes();
+  $response = digitalmeasures_digitalmeasures_get_all_indexes();
+
+  drush_print_r($response);
+  if (module_exists('devel_debug_log')) {
+    ddl($response);
+  }
 }

--- a/digitalmeasures.module
+++ b/digitalmeasures.module
@@ -117,10 +117,6 @@ function _digital_measures_render_response_data($response, $output) {
     $response = _digitalmeasures_xml_to_array($response->data);
   }
 
-  drush_print_r($response);
-  if (module_exists('devel_debug_log')) {
-    ddl($response);
-  }
   return $response;
 }
 


### PR DESCRIPTION
Minor change to allow `digitalmeasures_digitalmeasures_get_schemadata()` to be used outside of Drush
